### PR TITLE
Serial port emulation

### DIFF
--- a/Readme-serial.txt
+++ b/Readme-serial.txt
@@ -1,0 +1,106 @@
+Serial port emulation is provided by emulating the SCN2681 dual asynchronous
+receiver/transmitter (DUART) device supported by the Plus 1 Electron Expansion
+ROM. This document describes the extent of the support and current
+limitations, and it should be updated as this support evolves.
+
+To use these emulation features, make sure that the plus1.rom file is present
+in the roms directory and that the Plus 1 is enabled in the elk.cfg
+configuration file as follows:
+
+  plus1 = 1
+
+To interact with the emulated system over a serial connection, a simple client
+program is provided that can be run as follows:
+
+  tools/serial_client.py
+
+This will output the name of a file to be used to connect the client with
+Elkulator. For example:
+
+  Waiting for connection at: /tmp/tmpIIrGMc
+
+Alternatively, a filename can be indicated as follows:
+
+  tools/serial_client.py xxx
+
+Elkulator should be run with the -serial option indicating the appropriate
+filename. For example:
+
+  ./elkulator -serial xxx
+
+If Elkulator cannot connect to the client, it will start up successfully but
+report an error. For example:
+
+  Failed to connect to serial communications socket: No such file or directory
+
+Elkulator can also be asked to provide more information about its serial
+emulation activities using the -serialdebug option with a debugging level
+argument. For example:
+
+  ./elkulator -serial xxx -serialdebug 1
+
+In the emulated Electron, the following commands are useful:
+
+  *FX 2,1 - enables the RS423 input stream, disabling the keyboard, with the
+            client being needed for further input
+
+  *FX 3,1 - enables the RS423 output stream along with the VDU output
+
+  *FX 3,3 - enables only the RS423 output, hiding VDU output
+
+  *FX 5,2 - selects the serial printer which can then be enabled using Ctrl-B
+            or VDU 2, and disabled using Ctrl-C or VDU 3
+
+Currently, the serial client performs end-of-line character conversion to
+permit its use as a simple console.
+
+----
+
+Support for serial communications is found in the following files:
+
+src/6502.c   - invokes the polling routine for the emulated device
+src/main.c   - provides command line options for serial emulation features
+src/mem.c    - tests for access to memory addresses exposing the SCN2681 
+src/serial.c - provides the basis of the SCN2681 emulation
+
+The SCN2681 has apparently been available in a number of different profiles.
+The 40-pin DIP and 44-pin PLCC profiles offer the full range of input and
+output pins and ports, whereas the 24-pin and 28-pin DIP profiles offer a
+reduced number of pins and ports. Since Electron expansions are likely to use
+the smaller packages, and since the Plus 1 ROM code makes limited use of the
+SCN2681 feature set, only limited support is provided for input and output
+pins and ports.
+
+In this emulation, of the input ports only IP0, IP1 and IP2 are tested, with
+IP0 and IP1 potentially being employed for clear-to-send (CTS) control
+purposes.  However, only IP2 is actually available on the 28-pin device and no
+input ports are provided on the 24-pin device. For output, only OP0 and OP1
+are employed, these potentially being employed for request-to-send (RTS)
+control purposes. These ports are available on all but the 24-pin device.
+
+The SCN2681 supports a degree of flexibility with regard to clock and
+frequency configuration, with various input port pins permitting external
+clock signals to be used: IP3 and IP4 for channel A; IP5 and IP6 for channel
+B. Frequencies derived from such signals are then exposed via the baud rate
+configuration on a real SCN2681 device. This emulation does not support such
+external frequencies and the selection of such externally derived frequencies
+will inhibit communication.
+
+Currently, none of the detail of serial communication is emulated beyond a
+simple attempt to replicate transmission and reception at a given baud rate
+and to support different character sizes. The device can be configured for
+different parities and stop bits, but such details are not represented in any
+communication. Similarly, break signals are recorded but not represented. Such
+details might in future be represented using a protocol encoding them over a
+normal communications stream, or a more sophisticated medium might be
+employed.
+
+Since the first in, first out (FIFO) mechanism for receiving characters is
+emulated, overrun errors should be handled. Other forms of error such as
+parity and framing errors will not occur since the underlying communications
+medium should not produce them. However, support is present for recording and
+representing such errors.
+
+Support for various channel features such as auto-echo and loopback is absent.
+Similarly, multidrop support is absent. The general counter/timer support is
+also not emulated.

--- a/src/6502.c
+++ b/src/6502.c
@@ -1756,6 +1756,7 @@ void exec6502()
                                         plus1stat&=~0x40;
                                 }
                         }
+                        if (plus1) pollserial(oldcycs);
                 }
                         if (tapespeed==TAPE_REALLY)
                         {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,6 @@ endif
 
 elkulator_SOURCES = 2xsai.c 1770.c 6502.c adc.c adf.c config.c csw.c ddnoise.c \
 debugger.c disc.c fdi2raw.c fdi.c firstbyte.c linux.c linux-gui.c \
-linux-keydefine.c main.c mem.c palfilt.c savestate.c scale2x.c sound.c soundopenal.c ssd.c \
+linux-keydefine.c main.c mem.c palfilt.c savestate.c scale2x.c serial.c sound.c soundopenal.c ssd.c \
 tapenoise.c uef.c ula.c allegro_icon.c
 

--- a/src/elk.h
+++ b/src/elk.h
@@ -248,6 +248,7 @@ void writeula(uint16_t addr, uint8_t val);
 void yield();
 void waitforramsync();
 void intula(uint8_t num);
+void clearintula(uint8_t num);
 void receive(uint8_t val);
 void enterfullscreen();
 void leavefullscreen();
@@ -260,6 +261,11 @@ void saveulastate(FILE *f);
 void reset1770();
 uint8_t read1770(uint16_t addr);
 void write1770(uint16_t addr, uint8_t val);
+
+void resetserial();
+uint8_t readserial(uint16_t addr);
+void writeserial(uint16_t addr, uint8_t val);
+void pollserial(int cycles);
 
 void loadtape(char *fn);
 void reallyfasttapepoll();

--- a/src/main.c
+++ b/src/main.c
@@ -63,16 +63,19 @@ void cleardrawit()
 char tapename[512];
 char romname[512];
 char romname2[512];
+char serialname[512];
+extern int serial_debug;
 
 void initelk(int argc, char *argv[])
 {
         int c;
         char *p;
-        int tapenext=0,discnext=0,romnext=0;
+        int tapenext=0,discnext=0,romnext=0,serialnext=0,serialdebugnext=0;
         get_executable_name(exedir,511);
         p=get_filename(exedir);
         p[0]=0;
         romname[0]=romname2[0]=discname[0]=discname2[0]=tapename[0]=0;
+        serialname[0]=0;
 //        printf("Load config\n");
         loadconfig();
 //printf("commandline\n");
@@ -96,6 +99,8 @@ void initelk(int argc, char *argv[])
                         printf("-tape tape.uef  - load tape.uef\n");
                         printf("-rom1 rom       - load rom into cartridge ROM bank 1\n");
                         printf("-rom2 rom       - load rom into cartridge ROM bank 2\n");
+                        printf("-serial file    - use file as a socket for serial communications\n");
+                        printf("-serialdebug n  - set serial debugging output level to n\n");
                         printf("-debug          - start debugger\n");
                         exit(-1);
                 }
@@ -121,6 +126,14 @@ void initelk(int argc, char *argv[])
                 {
                         romnext=2;
                 }
+                else if (!strcasecmp(argv[c],"-serial"))
+                {
+                        serialnext=1;
+                }
+                else if (!strcasecmp(argv[c],"-serialdebug"))
+                {
+                        serialdebugnext=1;
+                }
                 else if (!strcasecmp(argv[c],"-debug"))
                 {
                         debug=debugon=1;
@@ -138,6 +151,16 @@ void initelk(int argc, char *argv[])
                         if (romnext==2) strcpy(romname2,argv[c]);
                         if (romnext==1) strcpy(romname,argv[c]);
                         romnext=0;
+                }
+                else if (serialnext)
+                {
+                        strcpy(serialname,argv[c]);
+                        serialnext=0;
+                }
+                else if (serialdebugnext)
+                {
+                        serial_debug = atoi(argv[c]);
+                        serialdebugnext=0;
                 }
                 if (tapenext) tapenext--;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -151,6 +151,7 @@ void initelk(int argc, char *argv[])
         initula();
         resetula();
         reset1770();
+        resetserial();
         
         loadtape(tapename);
         loaddisc(0,discname);

--- a/src/mem.c
+++ b/src/mem.c
@@ -132,6 +132,7 @@ uint8_t readmem(uint16_t addr)
                         if (addr==0xFC70) return readadc();
                         if (addr==0xFC72) return getplus1stat();
                 }
+                if (addr>=0xFC60 && addr<=0xFC6F && plus1) return readserial(addr);
 //                if ((addr&~0x1F)==0xFC20) return readsid(addr);
                 return addr>>8;
         }
@@ -212,6 +213,7 @@ void writemem(uint16_t addr, uint8_t val)
 //                if (!val) output=1;
         }
         if (addr==0xFC70 && plus1) writeadc(val);
+        if (addr>=0xFC60 && addr<=0xFC6F && plus1) return writeserial(addr, val);
 }
 
 int keys[2][14][4]=

--- a/src/serial.c
+++ b/src/serial.c
@@ -78,7 +78,7 @@ enum sr_fc_address
 
 /* Serial register storage. */
 
-static uint8_t sr[16];
+static uint8_t sr[10];
 
 /* Serial register locations for registers requiring storage. */
 

--- a/src/serial.c
+++ b/src/serial.c
@@ -1,0 +1,1105 @@
+/*
+ * Serial/UART emulation for Elkulator.
+ *
+ * See: SCN2681 Dual asynchronous receiver/transmitter (DUART)
+ *
+ * Copyright (C) 2022 Paul Boddie <paul@boddie.org.uk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include "elk.h"
+
+
+
+/* Serial cycle counter. */
+
+static int serial_cycles;
+
+
+
+/* Serial register locations in the Electron memory map. */
+
+enum sr_fc_address
+{
+        FC_BASE  = 0xFC60,
+        FC_MRxA  = 0xFC60, /* Mode register A (MR1A, MR2A) */
+        FC_SRA   = 0xFC61, /* Status register A (SRA) */
+        FC_CSRA  = 0xFC61, /* Clock select register A (CSRA) */
+        FC_CRA   = 0xFC62, /* Command register A (CRA) */
+        FC_RHRA  = 0xFC63, /* Receive holding register A (RHRA) */
+        FC_THRA  = 0xFC63, /* Transmit holding register A (THRA) */
+        FC_IPCR  = 0xFC64, /* Input port change register (IPCR) */
+        FC_ACR   = 0xFC64, /* Aux control register (ACR) */
+        FC_ISR   = 0xFC65, /* Interrupt status register (ISR) */
+        FC_IMR   = 0xFC65, /* Interrupt mask register (IMR) */
+        FC_MRxB  = 0xFC68, /* Mode register B (MR1B, MR2B) */
+        FC_SRB   = 0xFC69, /* Status register B (SRB) */
+        FC_CSRB  = 0xFC69, /* Clock select register B (CSRB) */
+        FC_CRB   = 0xFC6A, /* Command register B (CRB) */
+        FC_RHRB  = 0xFC6B, /* Receive holding register B (RHRB) */
+        FC_THRB  = 0xFC6B, /* Transmit holding register B (THRB) */
+        FC_IP06  = 0xFC6D, /* Input ports IP0 to IP6 */
+        FC_OPCR  = 0xFC6D, /* Output port configuration register (OPCR) */
+        FC_STCC  = 0xFC6E, /* Start counter command */
+        FC_SOPBC = 0xFC6E, /* Set output port bits command */
+        FC_SPCC  = 0xFC6F, /* Stop counter command */
+        FC_ROPBC = 0xFC6F  /* Reset output port bits command */
+};
+
+/* Serial register storage. */
+
+static uint8_t sr[16];
+
+/* Serial register locations for registers requiring storage. */
+
+enum sr_pos
+{
+        IPCR, ACR, ISR, IMR, CTU, CRUR, CTL, CTLR, IP06, OPCR
+};
+
+static const int SR_max = OPCR;
+
+/* Mode register locations. */
+
+enum MR_indexes
+{
+        MR1 = 0, MR2 = 1
+};
+
+/* Register field definitions. */
+
+enum MR1_bits
+{
+        MR1_RxRTS = 0x80,
+        MR1_RxINT = 0x40,
+        MR1_block_error = 0x20,
+        MR1_parity_mode = 0x18,
+        MR1_parity_mode_shift = 3,
+        MR1_parity_type = 0x04,
+        MR1_bpc = 0x03
+};
+
+enum MR2_bits
+{
+        MR2_channel = 0xc0,
+        MR2_channel_shift = 6,
+        MR2_TxRTS = 0x20,
+        MR2_TxCTS = 0x10,
+        MR2_stop_bits = 0x0f
+};
+
+enum SR_bits
+{
+        SR_receive_break = 0x80,
+        SR_framing_error = 0x40,
+        SR_parity_error = 0x20,
+        SR_overrun_error = 0x10,
+        SR_TxEMT = 0x08,
+        SR_TxRDY = 0x04,
+        SR_FFULL = 0x02,
+        SR_RxRDY = 0x01
+};
+
+enum OPCR_bits
+{
+        OPCR_TxRDYB = 0x80,
+        OPCR_TxRDYA = 0x40,
+        OPCR_RxRDY_FFULL_B = 0x20,
+        OPCR_RxRDY_FFULL_A = 0x10,
+        OPCR_OP3 = 0x0c,
+        OPCR_OP3_shift = 2,
+        OPCR_OP2 = 0x03
+};
+
+enum CSR_bits
+{
+        CSR_receive = 0xf0,
+        CSR_receive_shift = 4,
+        CSR_transmit = 0x0f
+};
+
+enum CR_bits
+{
+        CR_command = 0x70,
+        CR_command_shift = 4,
+        CR_disable_Tx = 0x08,
+        CR_enable_Tx = 0x04,
+        CR_disable_Rx = 0x02,
+        CR_enable_Rx = 0x01
+};
+
+enum CR_command_values
+{
+        CR_command_reset_MR = 1,
+        CR_command_reset_receiver = 2,
+        CR_command_reset_transmitter = 3,
+        CR_command_reset_error = 4,
+        CR_command_reset_break_change = 5,
+        CR_command_start_break = 6,
+        CR_command_stop_break = 7
+};
+
+enum ACR_bits
+{
+        ACR_BRG = 0x80,
+        ACR_BRG_shift = 7,
+        ACR_CTMS = 0x70,
+        ACR_CTMS_shift = 4,
+        ACR_delta_IP3 = 0x08,
+        ACR_delta_IP2 = 0x04,
+        ACR_delta_IP1 = 0x02,
+        ACR_delta_IP0 = 0x01
+};
+
+enum IMR_bits
+{
+        IMR_IP_change = 0x80,
+        IMR_delta_break_B = 0x40,
+        IMR_RxRDY_FFULL_B = 0x20,
+        IMR_TxRDYB = 0x10,
+        IMR_counter_ready = 0x08,
+        IMR_delta_break_A = 0x04,
+        IMR_RxRDY_FFULL_A = 0x02,
+        IMR_TxRDYA = 0x01
+};
+
+enum ISR_bits
+{
+        ISR_IP_change = 0x80,
+        ISR_delta_break_B = 0x40,
+        ISR_RxRDY_FFULL_B = 0x20,
+        ISR_TxRDYB = 0x10,
+        ISR_counter_ready = 0x08,
+        ISR_delta_break_A = 0x04,
+        ISR_RxRDY_FFULL_A = 0x02,
+        ISR_TxRDYA = 0x01
+};
+
+enum IP06_bits
+{
+        IP06_IP2 = 0x04,
+        IP06_CTSBN = 0x02,
+        IP06_CTSAN = 0x01
+};
+
+enum OPBC_bits
+{
+        OPBC_RTSBN = 0x02,
+        OPBC_RTSAN = 0x01
+};
+
+
+
+/* Readable forms for register names and various fields. */
+
+static char *sr_read_names[] = {
+        "MRxA", "SRA", "-", "RHRA", "IPCR", "ISR", "CTU", "CTL",
+        "MRxB", "SRB", "-", "RHRB", "-", "IP0-6", "STCC", "SPCC"
+        };
+
+static char *sr_write_names[] = {
+        "MRxA", "CSRA", "CRA", "THRA", "ACR", "IMR", "CRUR", "CTLR",
+        "MRxB", "CSRB", "CRB", "THRB", "-", "OPCR", "SOPBC", "ROPBC"
+        };
+
+static char *parity_mode[] = {
+        "with parity", "force parity", "no parity", "multidrop"
+        };
+
+static char *channel_mode[] = {
+        "normal", "auto-echo", "local loop", "remote loop"
+        };
+
+static char *commands[] = {
+        "no command", "reset MR", "reset receiver", "reset transmitter",
+        "reset error", "reset break change A", "start break", "stop break"
+        };
+
+static char *stop_bits[] = {
+        "0.563", "0.625", "0.688", "0.750", "0.813", "0.875", "0.938", "1.000",
+        "1.563", "1.625", "1.688", "1.750", "1.813", "1.875", "1.938", "2.000"
+        };
+
+static char *stop_bits_5bpc[] = {
+        "1.063", "1.125", "1.188", "1.250", "1.313", "1.375", "1.438", "1.500",
+        "2.063", "2.125", "2.188", "2.250", "2.313", "2.375", "2.438", "2.500"
+        };
+
+static char *opcr_op2[] = {
+        "OPR[2]", "TxCA(16x)", "TxCA(1x)", "RxCA(1x)"
+        };
+
+static char *opcr_op3[] = {
+        "OPR[3]", "C/T output", "TxCB(1x)", "RxCB(1x)"
+        };
+
+
+
+/* Baud rate labels. */
+
+static char *baud_rate_labels[2][16] = {
+        {
+                "50", "110", "134.5", "200", "300", "600", "1200", "1050",
+                "2400", "4800", "7200", "9600", "38400", "timer", "IPx-16X", "IPx-1X"
+        },
+        {
+                "75", "110", "134.5", "150", "300", "600", "1200", "2000",
+                "2400", "4800", "1800", "9600", "19200", "timer", "IPx-16X", "IPx-1X"
+        }};
+
+/* Baud rates with unsupported rates represented by zero. */
+
+static float baud_rates[2][16] = {
+        {
+                50, 110, 134.5, 200, 300, 600, 1200, 1050,
+                2400, 4800, 7200, 9600, 38400, 0, 0, 0
+        },
+        {
+                75, 110, 134.5, 150, 300, 600, 1200, 2000,
+                2400, 4800, 1800, 9600, 19200, 0, 0, 0
+        }};
+
+/* Functions for accessing baud rate settings. */
+
+static int baud_rate_group()
+{
+        return (sr[ACR] & ACR_BRG) >> ACR_BRG_shift;
+}
+
+
+
+/* Channel-related state abstractions. */
+
+/* Receive holding register FIFO for RHRA and RHRB. */
+
+struct rhr_flags
+{
+        unsigned int parity_error : 1;
+        unsigned int framing_error : 1;
+        unsigned int received_break : 1;
+};
+
+struct rhr_fifo
+{
+        /* FIFO data and flag storage. */
+
+        uint8_t data[3];
+        struct rhr_flags flags[3];
+
+        /* Front and back of the received data. */
+
+        int front, back;
+};
+
+static void reset_fifo(struct rhr_fifo *fifo)
+{
+        int i;
+
+        for (i = 0; i < 3; i++)
+        {
+                fifo->data[i] = 0;
+                fifo->flags[i] = (struct rhr_flags) {0, 0, 0};
+        }
+
+        fifo->front = 0;
+        fifo->back = 0;
+}
+
+/* A channel abstraction. */
+
+struct channel
+{
+        /* Conditions. */
+
+        int cts, rts;
+
+        /* Transmit and receive shift registers. */
+
+        uint8_t tsr, rsr;
+        int tsr_bits_remaining, rsr_bits_received;
+
+        /* Receive holding register FIFO. */
+
+        struct rhr_fifo fifo;
+
+        /* Channel state flags. */
+
+        int transmit_enabled, receive_enabled;
+        int break_started;
+
+        /* State to detect THR usage separately from TxEMT. */
+
+        int THR_set;
+
+        /* Mode registers and index. */
+
+        uint8_t mr[2];
+        int mr_index;
+
+        /* Channel-specific registers. */
+
+        uint8_t CSR, SR, THR;
+
+        /* Channel-dependent values for common registers. */
+
+        uint8_t IP06_CTS_flag, ISR_delta_break_flag, ISR_TxRDY_flag;
+
+        /* Cycles per character. */
+
+        int receive_cycles, transmit_cycles;
+
+        /* The output character actually sent. */
+
+        uint8_t output_char;
+};
+
+/* The channel objects. */
+
+static struct channel channels[2];
+
+
+
+/* Channel settings. */
+
+static int channel_baud_rate_receive_index(struct channel *ch)
+{
+        return (ch->CSR & CSR_receive) >> CSR_receive_shift;
+}
+
+static float channel_baud_rate_receive(struct channel *ch)
+{
+        return baud_rates[baud_rate_group()][channel_baud_rate_receive_index(ch)];
+}
+
+static int channel_baud_rate_transmit_index(struct channel *ch)
+{
+        return ch->CSR & CSR_transmit;
+}
+
+static float channel_baud_rate_transmit(struct channel *ch)
+{
+        return baud_rates[baud_rate_group()][channel_baud_rate_transmit_index(ch)];
+}
+
+static void channel_baud_rate_update(struct channel *ch)
+{
+        ch->receive_cycles = 2000000 / channel_baud_rate_receive(ch);
+        ch->transmit_cycles = 2000000 / channel_baud_rate_transmit(ch);
+
+        fprintf(stderr, "transmit=%d receive=%d\n", ch->transmit_cycles, ch->receive_cycles);
+}
+
+static int channel_bpc(struct channel *ch)
+{
+        return (ch->mr[MR1] & MR1_bpc) + 5;
+}
+
+/* Channel operations. */
+
+static void channel_clock_select(struct channel *ch, uint8_t val)
+{
+        ch->CSR = val;
+
+        fprintf(stderr, "CSR%c: receiver=%s transmitter=%s\n",
+                ch == &channels[0] ? 'A' : 'B',
+                baud_rate_labels[baud_rate_group()][channel_baud_rate_receive_index(ch)],
+                baud_rate_labels[baud_rate_group()][channel_baud_rate_transmit_index(ch)]);
+
+        channel_baud_rate_update(ch);
+}
+
+static void channel_transmit_not_ready(struct channel *ch)
+{
+        ch->SR &= ~SR_TxRDY;
+        sr[ISR] &= ~ch->ISR_TxRDY_flag;
+}
+
+static void channel_transmit_ready(struct channel *ch)
+{
+        ch->SR |= SR_TxRDY;
+        sr[ISR] |= ch->ISR_TxRDY_flag;
+}
+
+static void channel_disable_receiver(struct channel *ch)
+{
+        ch->receive_enabled = 0;
+}
+
+static void channel_disable_transmitter(struct channel *ch)
+{
+        ch->transmit_enabled = 0;
+        ch->SR &= ~SR_TxEMT;
+        channel_transmit_not_ready(ch);
+}
+
+static void channel_enable_receiver(struct channel *ch)
+{
+        ch->receive_enabled = 1;
+}
+
+static void channel_enable_transmitter(struct channel *ch)
+{
+        ch->transmit_enabled = 1;
+        ch->SR |= SR_TxEMT;
+        ch->THR_set = 0;
+        channel_transmit_ready(ch);
+}
+
+static uint8_t channel_get_mode(struct channel *ch)
+{
+        uint8_t val = ch->mr[ch->mr_index];
+        ch->mr_index = 1;
+        return val;
+}
+
+static uint8_t channel_read(struct channel *ch)
+{
+        uint8_t val = ch->fifo.data[ch->fifo.front];
+
+        if (ch->fifo.front != ch->fifo.back)
+                ch->fifo.front = (ch->fifo.front + 1) % 3;
+
+        if (!(ch->mr[MR1] & MR1_block_error))
+                ch->SR &= ~(SR_receive_break | SR_parity_error | SR_framing_error);
+
+        return val;
+}
+
+static void channel_reset_output(struct channel *ch)
+{
+        ch->cts = 0;
+        ch->rts = 0;
+}
+
+static void channel_reset_receiver(struct channel *ch)
+{
+        reset_fifo(&ch->fifo);
+
+        ch->receive_enabled = 0;
+        ch->mr_index = 0;
+        ch->rsr = 0;
+        ch->rsr_bits_received = 0;
+}
+
+static void channel_reset_transmitter(struct channel *ch)
+{
+        ch->SR |= SR_TxEMT;
+        ch->THR_set = 0;
+
+        ch->transmit_enabled = 0;
+        ch->break_started = 0;
+        ch->tsr = 0;
+        ch->tsr_bits_remaining = 0;
+}
+
+static void channel_reset(struct channel *ch)
+{
+        int pos;
+
+        channel_reset_output(ch);
+        channel_reset_receiver(ch);
+        channel_reset_transmitter(ch);
+
+        ch->receive_cycles = 0;
+        ch->transmit_cycles = 0;
+
+        ch->CSR = 0;
+        ch->SR = 0;
+        ch->THR = 0;
+
+        /* Set mode registers. */
+
+        for (pos = 0; pos < 2; pos++)
+                ch->mr[pos] = 0;
+}
+
+static void channel_rts_clear(struct channel *ch)
+{
+        ch->rts = 0;
+}
+
+static void channel_rts_set(struct channel *ch)
+{
+        ch->rts = 1;
+}
+
+static void channel_set_mode(struct channel *ch, uint8_t val)
+{
+        switch (ch->mr_index)
+        {
+                case MR1:
+                fprintf(stderr, "MR1%c: BPC=%d parity=\"%s\" mode=\"%s\" error=%s RxINT=%s RxRTS=%s\n",
+                        ch == &channels[0] ? 'A' : 'B',
+                        channel_bpc(ch),
+                        val & MR1_parity_type ? "odd" : "even",
+                        parity_mode[(val & MR1_parity_mode) >> MR1_parity_mode_shift],
+                        val & MR1_block_error ? "block" : "char",
+                        val & MR1_RxINT ? "FFULL" : "RxRDY",
+                        val & MR1_RxRTS ? "yes" : "no");
+                break;
+
+                case MR2:
+                fprintf(stderr, "MR2%c: stop=%s TxCTS=%s TxRTS=%s channel=%s\n",
+                        ch == &channels[0] ? 'A' : 'B',
+                        (channel_bpc(ch) == 5 ? stop_bits_5bpc : stop_bits)[val & MR2_stop_bits],
+                        val & MR2_TxCTS ? "yes" : "no",
+                        val & MR2_TxRTS ? "yes" : "no",
+                        channel_mode[(val & MR2_channel) >> MR2_channel_shift]);
+                break;
+        }
+
+        ch->mr[ch->mr_index] = val;
+        ch->mr_index = 1;
+}
+
+static void channel_write(struct channel *ch, uint8_t val)
+{
+        fprintf(stderr, "THR%c: %02x\n",
+                ch == &channels[0] ? 'A' : 'B',
+                val);
+
+        if (ch->SR & CR_enable_Tx)
+        {
+                ch->THR = val;
+                ch->SR &= ~SR_TxEMT;
+                ch->THR_set = 1;
+                channel_transmit_not_ready(ch);
+        }
+}
+
+static void channel_command(struct channel *ch, uint8_t val)
+{
+        struct rhr_fifo *fifo = &ch->fifo;
+        int Rx_op = val & (CR_enable_Rx | CR_disable_Rx);
+        int Tx_op = val & (CR_enable_Tx | CR_disable_Tx);
+
+        fprintf(stderr, "CR%c:", ch == &channels[0] ? 'A' : 'B');
+
+        fprintf(stderr, " command=\"%s\"",
+                commands[(val & CR_command) >> CR_command_shift]);
+
+        switch ((val & CR_command) >> CR_command_shift)
+        {
+                case CR_command_reset_MR:
+                ch->mr_index = 0;
+                break;
+
+                case CR_command_reset_receiver:
+                if (!Rx_op)
+                        channel_reset_receiver(ch);
+                break;
+
+                case CR_command_reset_transmitter:
+                if (!Tx_op)
+                        channel_reset_transmitter(ch);
+                break;
+
+                case CR_command_reset_error:
+                ch->SR &= ~(SR_receive_break | SR_parity_error | SR_framing_error);
+                break;
+
+                case CR_command_reset_break_change:
+                sr[ISR] &= ~(ch->ISR_delta_break_flag);
+                break;
+
+                case CR_command_start_break:
+                if (ch->transmit_enabled)
+                        ch->break_started = 1;
+                break;
+
+                case CR_command_stop_break:
+                ch->break_started = 0;
+                break;
+
+                default:
+                break;
+        }
+
+        /* Separate channel modification bits. */
+
+        if (!ch->receive_enabled && (val & CR_enable_Rx))
+        {
+                fprintf(stderr, " enable Rx=%s",
+                        val & CR_enable_Rx ? "yes" : "no");
+                channel_enable_receiver(ch);
+        }
+        else if (ch->receive_enabled && (val & CR_disable_Rx))
+        {
+                fprintf(stderr, " disable Rx=%s",
+                        val & CR_disable_Rx ? "yes" : "no");
+                channel_disable_receiver(ch);
+        }
+
+        if (!ch->transmit_enabled && (val & CR_enable_Tx))
+        {
+                fprintf(stderr, " enable Tx=%s",
+                        val & CR_enable_Tx ? "yes" : "no");
+                channel_enable_transmitter(ch);
+        }
+        else if (ch->transmit_enabled && (val & CR_disable_Tx))
+        {
+                fprintf(stderr, " disable Tx=%s",
+                        val & CR_disable_Tx ? "yes" : "no");
+                channel_disable_transmitter(ch);
+        }
+
+        fprintf(stderr, "\n");
+}
+
+
+
+/* Receive data.
+
+   The receive shift register is populated as bits are detected on the RxD pin,
+   for the start bit, data bits (least significant bit first), parity and stop
+   bits.
+
+   The data is then transferred to the FIFO for this register at the back of the
+   queue, with any unused data bits being set to zero.
+
+   Any parity and framing errors along with any received break state are
+   recorded along with the data in the FIFO. These conditions along with any
+   overrun condition are also set in the status register, depending on the error
+   mode chosen.
+
+   In character error mode, the status register reflects the next available
+   character in the FIFO.
+
+   In block error mode, the status register reflects the cumulative error state,
+   with each successive character setting (but not clearing) the status
+   register bits. The error state is reset using the reset error command or in
+   a receiver reset.
+
+   After any updates to the status register, RxRDY is then set in the status
+   register.
+
+   A received break condition causes a zero character to be loaded into the FIFO
+   to accompany the received break bit being set in the status register.
+
+   When all FIFO elements are full, the FFULL condition occurs and is set in the
+   status register. Any subsequently received characters will populate only the
+   shift register, and if the shift register is overwritten, an overrun
+   condition will be recorded.
+
+   Disabling the receiver loses the shift register contents but preserves the
+   FIFO data. Resetting the receiver discards the shift register contents and
+   resets the FIFO pointers to an empty state, although the FIFO will retain
+   previously received data.
+*/
+
+static void receive_data(struct channel *ch)
+{
+        /* NOTE: Multidrop mode supposedly has the receiver active even if not
+                 enabled. */
+
+        if (!ch->receive_enabled)
+                return;
+
+/*
+        uint8_t val = ch->fifo.data[ch->fifo.front];
+
+        if (ch->fifo.front != ch->fifo.back)
+                ch->fifo.front = (ch->fifo.front + 1) % 3;
+
+        if (!(ch->mr[MR1] & MR1_block_error))
+                ch->SR &= ~(SR_receive_break | SR_parity_error | SR_framing_error);
+*/
+}
+
+/* Transmit data.
+
+   When able to transmit, the TxRDY bit is set in the status register. TxRDY is
+   cleared when a value is written to the transmit holding register. When a new
+   character can be sent, the value is then transferred to the transmit shift
+   register, and TxRDY is set again.
+
+   The shift register bits are converted to signals on the TxD pin. A start bit,
+   data bits (least significant bit first), parity and stop bits.
+
+   Between characters, the TxD output remains high and the TxEMT (empty) bit in
+   the status register is set to 1. TxEMT is cleared when a value is written to
+   the transmit holding register.
+
+   A send break command causes the transmitter to send a continuous low
+   condition.
+*/
+
+static void transmit_data(struct channel *ch)
+{
+        /* Any partially transmitted character will be sent. */
+
+        if (!ch->transmit_enabled && !ch->tsr_bits_remaining)
+                return;
+
+        /* Attempt to send a new character. */
+
+        if (!(ch->SR & SR_TxEMT) && (!ch->tsr_bits_remaining))
+        {
+                ch->tsr = ch->THR;
+                ch->tsr_bits_remaining = channel_bpc(ch);
+                ch->THR_set = 0;
+                channel_transmit_ready(ch);
+                ch->output_char = 0;
+        }
+
+        /* Prevent transmission if controlled by CTSxN. */
+
+        if ((ch->mr[MR2] & MR2_TxCTS) && !(sr[IP06] & ch->IP06_CTS_flag))
+                return;
+
+        /* Test for an appropriate moment to send at the configured rate. */
+
+        if (!ch->transmit_cycles || (serial_cycles < ch->transmit_cycles))
+                return;
+
+        serial_cycles = serial_cycles % ch->transmit_cycles;
+
+        /* At the appropriate rate, send any bits in the shift register. */
+
+        if (ch->tsr_bits_remaining)
+        {
+                ch->tsr_bits_remaining--;
+
+                /* Send each bit somewhere. */
+
+                ch->output_char |= ch->tsr & (1 << ch->tsr_bits_remaining);
+
+                /* Test for the end of output. */
+
+                if (!ch->tsr_bits_remaining)
+                {
+                        /* Set the empty condition if the holding register was
+                           not set. */
+
+                        if (!ch->THR_set)
+                                ch->SR |= SR_TxEMT;
+
+                        /* NOTE: This might be written to some kind of file
+                                 descriptor for external use. */
+
+                        fprintf(stderr, "OUT %c: %02x\n",
+                                ch == &channels[0] ? 'A' : 'B',
+                                ch->output_char);
+                }
+        }
+}
+
+
+
+/* Input port handling. */
+
+static uint8_t get_input_port_change()
+{
+        uint8_t changed = 0;
+        int i;
+
+        /* Use the previous contents of IPCR together with IP06 for IP0..3 to
+           determine the new contents. */
+
+        for (i = 0; i < 4; i++)
+        {
+                if ((sr[IP06] & (1 << i)) != (sr[IPCR] & (1 << i)))
+                        changed |= (1 << i);
+        }
+
+        /* IPCR = delta (IP3..0) | IP3..0 */
+
+        sr[IPCR] = (changed << 4) | (sr[IP06] & 0x0f);
+        return changed;
+}
+
+static uint8_t read_input_port_change()
+{
+        /* Reset the interrupt status flag. */
+
+        sr[ISR] &= ~ISR_IP_change;
+        return sr[IPCR];
+}
+
+
+
+/* Output port handling. */
+
+static void reset_output_port(uint8_t val)
+{
+        fprintf(stderr, "ROPBC: %02x\n", val);
+        if (val & OPBC_RTSAN)
+                channel_rts_set(&channels[0]);
+        if (val & OPBC_RTSBN)
+                channel_rts_set(&channels[1]);
+}
+
+void serialinput(int);
+
+static void set_output_port(uint8_t val)
+{
+        fprintf(stderr, "SOPBC: %02x\n", val);
+        if (val & OPBC_RTSAN)
+                channel_rts_clear(&channels[0]);
+        if (val & OPBC_RTSBN)
+                channel_rts_clear(&channels[1]);
+}
+
+
+
+/* Interrupt handling. */
+
+static void update_interrupts()
+{
+        if (sr[IMR] & sr[ISR])
+                intula(1);
+        else
+                clearintula(1);
+}
+
+
+
+/* Reset common registers. */
+
+static void reset_registers()
+{
+        int i;
+
+        for (i = 0; i <= SR_max; i++)
+                sr[i] = 0;
+}
+
+
+
+/* Exported functions. */
+
+/* Change input port state. */
+
+void serialinput(int enable)
+{
+        if (enable)
+                sr[IP06] |= IP06_IP2;
+        else
+                sr[IP06] &= ~IP06_IP2;
+
+        /* Test for changed state and raise an interrupt if appropriate. */
+
+        if (get_input_port_change())
+                sr[ISR] |= ISR_IP_change;
+}
+
+/* Reset the serial controller's registers. */
+
+void resetserial()
+{
+        int i;
+
+        /* Initialise channels. */
+
+        channels[0].CSR = 0;
+        channels[1].CSR = 0;
+
+        channels[0].SR = 0;
+        channels[1].SR = 0;
+
+        channels[0].THR = 0;
+        channels[1].THR = 0;
+
+        channels[0].IP06_CTS_flag = IP06_CTSAN;
+        channels[1].IP06_CTS_flag = IP06_CTSBN;
+
+        channels[0].ISR_delta_break_flag = ISR_delta_break_A;
+        channels[1].ISR_delta_break_flag = ISR_delta_break_B;
+
+        channels[0].ISR_TxRDY_flag = ISR_TxRDYA;
+        channels[1].ISR_TxRDY_flag = ISR_TxRDYB;
+
+        /* Reset channels. */
+
+        for (i = 0; i < 2; i++)
+                channel_reset(&channels[i]);
+
+        reset_registers();
+
+        serial_cycles = 0;
+}
+
+/* Read from a serial controller register. */
+
+uint8_t readserial(uint16_t addr)
+{
+        uint8_t val = 0;
+
+        //fprintf(stderr, "read 0x%04x (%s) ->", addr, sr_read_names[addr - FC_BASE]);
+
+        switch (addr)
+        {
+                case FC_MRxA:
+                val = channel_get_mode(&channels[0]);
+                break;
+
+                case FC_SRA:
+                val = channels[0].SR;
+                break;
+
+                case FC_RHRA:
+                val = channel_read(&channels[0]);
+                break;
+
+                case FC_IPCR:
+                val = read_input_port_change();
+                break;
+
+                case FC_ISR:
+                val = sr[ISR];
+                break;
+
+                case FC_MRxB:
+                val = channel_get_mode(&channels[1]);
+                break;
+
+                case FC_SRB:
+                val = channels[1].SR;
+                break;
+
+                case FC_RHRB:
+                val = channel_read(&channels[1]);
+                break;
+
+                case FC_IP06:
+                val = sr[IP06];
+                break;
+
+                case FC_STCC:
+
+                case FC_SPCC:
+                default: break;
+        }
+
+        //fprintf(stderr, " %02x\n", val);
+        return val;
+}
+
+/* Write to a serial controller register. */
+
+void writeserial(uint16_t addr, uint8_t val)
+{
+        switch (addr)
+        {
+                case FC_MRxA:
+                channel_set_mode(&channels[0], val);
+                break;
+
+                case FC_CSRA:
+                channel_clock_select(&channels[0], val);
+                break;
+
+                case FC_CRA:
+                channel_command(&channels[0], val);
+                break;
+
+                case FC_THRA:
+                channel_write(&channels[0], val);
+                break;
+
+                case FC_ACR:
+                fprintf(stderr, "ACR: set=%d counter/timer=%d "
+                                "delta IP3 int=%s delta IP2 int=%s "
+                                "delta IP1 int=%s delta IP0 int=%s\n",
+                        ((val & ACR_BRG) >> ACR_BRG_shift) + 1,
+                        (val & ACR_CTMS) >> ACR_CTMS_shift,
+                        val & ACR_delta_IP3 ? "on" : "off",
+                        val & ACR_delta_IP2 ? "on" : "off",
+                        val & ACR_delta_IP1 ? "on" : "off",
+                        val & ACR_delta_IP0 ? "on" : "off");
+                sr[ACR] = val;
+                break;
+
+                case FC_IMR:
+                fprintf(stderr, "IMR: IP change=%s delta break B=%s "
+                                "RxRDY/FFULL B=%s TxRDYB=%s counter ready=%s "
+                                "delta break A=%s RxRDY/FFULL A=%s TxRDYA=%s\n",
+                        val & IMR_IP_change ? "on" : "off",
+                        val & IMR_delta_break_B ? "on" : "off",
+                        val & IMR_RxRDY_FFULL_B ? "on" : "off",
+                        val & IMR_TxRDYB ? "on" : "off",
+                        val & IMR_counter_ready ? "on" : "off",
+                        val & IMR_delta_break_A ? "on" : "off",
+                        val & IMR_RxRDY_FFULL_A ? "on" : "off",
+                        val & IMR_TxRDYA ? "on" : "off");
+                sr[IMR] = val;
+                break;
+
+                case FC_MRxB:
+                channel_set_mode(&channels[1], val);
+                break;
+
+                case FC_CSRB:
+                channel_clock_select(&channels[1], val);
+                break;
+
+                case FC_CRB:
+                channel_command(&channels[1], val);
+                break;
+
+                case FC_THRB:
+                channel_write(&channels[1], val);
+                break;
+
+                case FC_OPCR:
+                fprintf(stderr, "OPCR: OP7=%s OP6=%s OP5=%s OP4=%s OP3=%s OP2=%s\n",
+                        val & OPCR_TxRDYB ? "TxRDYB" : "OPR[7]",
+                        val & OPCR_TxRDYA ? "TxRDYA" : "OPR[6]",
+                        val & OPCR_RxRDY_FFULL_B ? "RxRDY/FFULL B" : "OPR[5]",
+                        val & OPCR_RxRDY_FFULL_A ? "RxRDY/FFULL A" : "OPR[4]",
+                        opcr_op3[(val & OPCR_OP3) >> OPCR_OP3_shift],
+                        opcr_op2[val & OPCR_OP2]);
+                sr[OPCR] = val;
+                break;
+
+                case FC_SOPBC:
+                set_output_port(val);
+                break;
+
+                case FC_ROPBC:
+                reset_output_port(val);
+                break;
+
+                default:
+                fprintf(stderr, "write 0x%04x (%s) <- %02x\n", addr, sr_write_names[addr - FC_BASE], val);
+                break;
+        }
+}
+
+/* Poll the serial controller, allowing it to do work for the given number of
+   2MHz cycles. */
+
+void pollserial(int cycles)
+{
+        int i;
+
+        serial_cycles += cycles;
+
+        for (i = 0; i < 2; i++)
+        {
+                /* If the receiver is enabled, obtain any shift register contents. */
+
+                receive_data(&channels[i]);
+
+                /* If the transmitter is enabled, send any shift register contents. */
+
+                transmit_data(&channels[i]);
+        }
+
+        /* Raise interrupt conditions. */
+
+        update_interrupts();
+}

--- a/src/ula.c
+++ b/src/ula.c
@@ -173,12 +173,14 @@ void resetula()
 
 void updateulaints()
 {
-        if (ula.isr&ula.ier&0x7C)
+        if (ula.isr & ula.ier & 0x7C)
         {
                 ula.isr|=1;
                 irq=1;
 //                printf("Interrupt %02X %02X\n",ula.isr,ula.ier);
         }
+        else if (ula.isr & 0x01)
+                irq = 1;
         else
         {
                 ula.isr&=~1;
@@ -198,6 +200,12 @@ void intula(uint8_t num)
         }
 //        if (num&0x10) printf("INT &0x10\n");
         ula.isr|=num;
+        updateulaints();
+}
+
+void clearintula(uint8_t num)
+{
+        ula.isr &= ~num;
         updateulaints();
 }
 

--- a/tools/serial_client.py
+++ b/tools/serial_client.py
@@ -40,10 +40,22 @@ class Reader:
 # Line ending conversion functions.
 
 def cr_to_lf(s):
-    return s.replace("\r", "\n")
+
+    """
+    Convert output from the Electron having optional line feeds to data
+    containing line feeds, replacing carriage returns.
+    """
+
+    return s.replace("\n", "").replace("\r", "\n")
 
 def lf_to_cr(s):
-    return s.replace("\n", "\r")
+
+    """
+    Handle input to the Electron having optional carriage returns to data
+    containing carriage returns, replacing line feeds.
+    """
+
+    return s.replace("\r", "").replace("\n", "\r")
 
 # Communications functions.
 

--- a/tools/serial_client.py
+++ b/tools/serial_client.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+"""
+Serial console for use with Elkulator serial port support.
+
+Copyright (C) 2022 Paul Boddie <paul@boddie.org.uk>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from os import read, remove, O_NONBLOCK
+from os.path import exists, isfile
+from socket import socket, AF_UNIX, SOCK_STREAM
+import select
+import sys
+
+# Conveniences.
+
+class Reader:
+
+    "A simple file-like object for direct stream access."
+
+    def __init__(self, fd):
+        self.fd = fd
+
+    def read(self, num):
+        return read(self.fd, num)
+
+# Line ending conversion functions.
+
+def cr_to_lf(s):
+    return s.replace("\r", "\n")
+
+def lf_to_cr(s):
+    return s.replace("\n", "\r")
+
+# Communications functions.
+
+def session(poller, channels):
+
+    "Use 'poller' to monitor the given 'channels'."
+
+    while 1:
+        fds = poller.poll()
+        for fd, status in fds:
+            if status & (select.POLLHUP | select.POLLNVAL | select.POLLERR):
+                print >>sys.stderr, "Connection closed."
+                return
+            elif status & select.POLLIN:
+                reader, writer, converter = channels[fd]
+                s = converter(reader.read(1))
+                writer.write(s)
+
+def main():
+
+    "Initialise a server socket and open a session."
+
+    # Obtain the communications socket filename and remove any previous socket file.
+
+    filename = sys.argv[1]
+
+    if exists(filename) and not isfile(filename):
+        remove(filename)
+
+    # Obtain a socket and bind it to the given filename.
+
+    s = socket(AF_UNIX, SOCK_STREAM)
+    s.bind(filename)
+    s.listen(0)
+
+    # Accept a connection.
+
+    print >>sys.stderr, "Waiting..."
+
+    c, addr = s.accept()
+
+    print >>sys.stderr, "Connection accepted."
+
+    # Employ file-like objects for reading and writing.
+
+    reader = c.makefile("r", 0)
+    writer = c.makefile("w", 0)
+
+    # Employ polling on the socket input and on standard input.
+
+    poller = select.poll()
+    poller.register(reader.fileno(), select.POLLIN | select.POLLHUP | select.POLLNVAL | select.POLLERR)
+    poller.register(sys.stdin.fileno(), select.POLLIN | select.POLLHUP | select.POLLNVAL | select.POLLERR)
+
+    # Map input descriptors to input streams, output streams and conversion
+    # functions.
+
+    channels = {
+        reader.fileno() : (reader, sys.stdout, cr_to_lf),
+        sys.stdin.fileno() : (Reader(sys.stdin.fileno()), writer, lf_to_cr)
+        }
+
+    # Initiate a session.
+
+    session(poller, channels)
+
+# Main program.
+
+if __name__ == "__main__":
+    main()
+
+# vim: tabstop=4 expandtab shiftwidth=4


### PR DESCRIPTION
This introduces serial port emulation that works with the Plus 1 enabled. An accompanying tool allows interaction with the emulated Electron. Many aspects of the serial hardware are not emulated, as described in the documentation.