### PR TITLE
Fixed common declarations and definitions.

### DIFF
--- a/src/csw.c
+++ b/src/csw.c
@@ -5,7 +5,7 @@
 #include "elk.h"
 
 #define HIGHTONE 0x40
-int reallyfasttapebreak;
+static int reallyfasttapebreak;
 int cintone=1,cindat=0,datbits=0,enddat=0;
 FILE *cswf;
 char csws[256];
@@ -13,7 +13,7 @@ FILE *cswlog;
 uint8_t *cswdat;
 int cswpoint;
 uint8_t cswhead[0x34];
-int tapelcount,tapellatch,pps;
+static int tapelcount,tapellatch,pps;
 int cswena;
 int cswskip=0;
 int tapespeed=0;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -451,7 +451,7 @@ void debugwrite(uint16_t addr, uint8_t val)
         }
 }
 
-uint16_t oldpc,oldoldpc;
+extern uint16_t oldpc;
 void dodebugger()
 {
         int c,d,e;
@@ -461,7 +461,7 @@ void dodebugger()
         char ins[256];
         if (!opcode)
         {
-                sprintf(outs,"BRK %04X! %04X %04X\n",pc,oldpc,oldoldpc);
+                sprintf(outs,"BRK %04X! %04X\n",pc,oldpc);
                 debugout(outs);
         }
         if (!opcode) debug=1;

--- a/src/disc.c
+++ b/src/disc.c
@@ -6,6 +6,19 @@
 #include <string.h>
 #include "elk.h"
 
+void (*fdccallback)();
+void (*fdcdata)(uint8_t dat);
+void (*fdcspindown)();
+void (*fdcfinishread)();
+void (*fdcnotfound)();
+void (*fdcdatacrcerror)();
+void (*fdcheadercrcerror)();
+void (*fdcwriteprotect)();
+int  (*fdcgetdata)(int last);
+
+struct drives drives[2];
+int curdrive;
+
 int discchanged[2]={0,0};
 
 struct

--- a/src/elk.h
+++ b/src/elk.h
@@ -34,7 +34,6 @@ uint8_t readmem(uint16_t addr);
 void writemem(uint16_t addr, uint8_t val);
 
 extern int cswena;
-extern int tapelcount,tapellatch;
 extern int tapeon;
 void polltape();
 void polluef();
@@ -91,7 +90,7 @@ extern int drawmode;
 extern int tapespeed;
 
 
-struct
+struct drives
 {
         void (*seek)(int drive, int track);
         void (*readsector)(int drive, int sector, int track, int side, int density);
@@ -99,9 +98,10 @@ struct
         void (*readaddress)(int drive, int track, int side, int density);
         void (*format)(int drive, int track, int side, int density);
         void (*poll)();
-} drives[2];
+};
 
-int curdrive;
+extern struct drives drives[2];
+extern int curdrive;
 
 void ssd_reset();
 void ssd_load(int drive, char *fn);
@@ -151,15 +151,15 @@ void setejecttext(int drive, char *fn);
 
 #define WD1770 1
 
-void (*fdccallback)();
-void (*fdcdata)(uint8_t dat);
-void (*fdcspindown)();
-void (*fdcfinishread)();
-void (*fdcnotfound)();
-void (*fdcdatacrcerror)();
-void (*fdcheadercrcerror)();
-void (*fdcwriteprotect)();
-int  (*fdcgetdata)(int last);
+extern void (*fdccallback)();
+extern void (*fdcdata)(uint8_t dat);
+extern void (*fdcspindown)();
+extern void (*fdcfinishread)();
+extern void (*fdcnotfound)();
+extern void (*fdcdatacrcerror)();
+extern void (*fdcheadercrcerror)();
+extern void (*fdcwriteprotect)();
+extern int  (*fdcgetdata)(int last);
 
 extern int writeprot[2],fwriteprot[2];
 extern int defaultwriteprot;
@@ -207,7 +207,7 @@ extern int ddvol,ddtype;
 extern int discspd;
 extern int motorspin;
 
-char exedir[512];
+extern char exedir[512];
 
 void initelk();
 void closeelk();

--- a/src/linux.c
+++ b/src/linux.c
@@ -9,7 +9,6 @@ char ssname[260];
 char scrshotname[260];
 char moviename[260];
 
-int tapespeed;
 int fullscreen=0;
 int gotofullscreen=0;
 int videoresize=0;

--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,7 @@ void cleardrawit()
         drawit--;
 }*/
 
+char exedir[512];
 char tapename[512];
 char parallelname[512];
 char serialname[512];

--- a/src/mem.c
+++ b/src/mem.c
@@ -11,7 +11,7 @@ int FASTHIGH2=0;
 //#define FASTLOW (turbo || (mrb && mrbmode && mrbmapped))
 #define FASTHIGH (FASTHIGH2 && ((pc&0xE000)!=0xC000))
 
-int output,timetolive;
+extern int output;
 int mrbmapped=0;
 int plus1=0;
 uint8_t readkeys(uint16_t addr);
@@ -222,7 +222,7 @@ uint8_t readmem(uint16_t addr)
         return os[addr&0x3FFF];
 }
 
-uint16_t pc;
+extern uint16_t pc;
 void writemem(uint16_t addr, uint8_t val)
 {
         if (debugon) debugwrite(addr,val);

--- a/src/sound.c
+++ b/src/sound.c
@@ -37,7 +37,6 @@ uint8_t snfreqhi[4],snfreqlo[4];
 uint8_t snvol[4];
 uint8_t snnoise;
 int lasttone;
-int soundon=1;
 int curwave=0;
 
 int16_t snwaves[5][32]=

--- a/src/uef.c
+++ b/src/uef.c
@@ -1,6 +1,6 @@
-int pauseit;
-int output;
-int reallyfasttapebreak;
+extern int pauseit;
+extern int output;
+static int reallyfasttapebreak;
 /*Elkulator v1.0 by Sarah Walker*/
 /*UEF handling*/
 #include <allegro.h>
@@ -10,10 +10,10 @@ int reallyfasttapebreak;
 
 #define INT_HIGHTONE 0x40
 
-int tapelcount,tapellatch,pps;
+static int tapelcount,tapellatch,pps;
 int intone=0;
 gzFile uef;
-int cswena;
+extern int cswena;
 
 int inchunk=0,chunkid=0,chunklen=0;
 int chunkpos=0,chunkdatabits=8;

--- a/src/ula.c
+++ b/src/ula.c
@@ -29,7 +29,7 @@ int irq=0,nmi=0;
 int extrom,rombank,intrombank;
 int tapeon;
 
-int soundlimit,soundon,soundcount,soundstat;
+int soundlimit,soundon=1,soundcount,soundstat;
 uint8_t sndstreambuf[626];
 int sndstreamindex = 0;
 int sndstreamcount = 0;
@@ -427,7 +427,7 @@ void tapenextbyte()
 
 int fasttapebreak;
 int pauseit=0;
-int cswena;
+extern int cswena;
 int bitcount;
 void polltape()
 {


### PR DESCRIPTION
Various declarations in elk.h that are repeatedly included along with definitions involving common names in other files result in "multiple definition" linking errors. These fixes attempt to ensure that names are only declared in elk.h and that they are defined only once elsewhere.