### PR TITLE
Prevent ROM paging if interrupt bits are set.

### DIFF
--- a/src/ula.c
+++ b/src/ula.c
@@ -246,12 +246,15 @@ void writeula(uint16_t addr, uint8_t val)
                 if (val&0x20) ula.isr&=~INT_RTC;
                 if (val&0x40) ula.isr&=~INT_HIGHTONE;
                 updateulaints();
-                rombank=val&0xF;
-                if (rombank>=0xC) extrom=1;
-                if ((rombank&0xC)==8)
+                if (!(val&0xF0))
                 {
-                        extrom=0;
-                        intrombank=rombank;
+                        rombank=val&0xF;
+                        if (rombank>=0xC) extrom=1;
+                        if ((rombank&0xC)==8)
+                        {
+                                extrom=0;
+                                intrombank=rombank;
+                        }
                 }
                 break;
                 case 6: /*Timer*/


### PR DESCRIPTION
According to recent investigations, the ULA will only change the selected ROM if the four upper bits of &FE05, used for changing interrupt-related state, are clear. This allows software to conveniently clear interrupts without inadvertently changing the selected ROM or needing to engage with the ROM selection logic.

See: https://stardot.org.uk/forums/viewtopic.php?t=27791