### PR TITLE
demrepofdave/fix_window_close_button_and_debug_build

### DIFF
--- a/src/linux-gui.c
+++ b/src/linux-gui.c
@@ -726,7 +726,7 @@ void entergui()
                 allegro_gl_set_allegro_mode();
         }*/
         dp=init_dialog(bemgui,0);
-        while (x && !menu_pressed() && !key[KEY_ESC])
+        while (x && !menu_pressed() && !key[KEY_ESC] && !quited)
         {
 /*                if (opengl)
                 {

--- a/src/linux.c
+++ b/src/linux.c
@@ -27,6 +27,11 @@ char discname2[260];
 int quited=0;
 int infocus=1;
 
+void native_window_close_button_handler(void)
+{
+       quited = 1;
+}
+
 void startblit()
 {
 }
@@ -45,6 +50,7 @@ int main(int argc, char *argv[])
                 exit(-1);
         }
         initelk(argc,argv);
+        set_close_button_callback(native_window_close_button_handler);
         install_mouse();
         while (!quited)
         {

--- a/src/palfilt.c
+++ b/src/palfilt.c
@@ -24,7 +24,7 @@ void initcoef()
 fixed yy[NCoef+2]; //output samples
 fixed yx[NCoef+2]; //input samples
 int ycount=0;
-inline fixed iir(fixed NewSample)
+static inline fixed iir(fixed NewSample)
 {
         yx[ycount] = NewSample;
         yy[ycount] = fixmul(ACoef2[0],yx[ycount]);
@@ -38,7 +38,7 @@ fixed ry[2]; //output samples
 fixed rx[2]; //input samples
 int rycount=0;
 
-inline fixed firry(fixed NewSample) {
+static inline fixed firry(fixed NewSample) {
     //Calculate the new output
     rx[rycount] = fixmul(ACoef[0],NewSample);
     ry[rycount] = rx[0]+rx[1];
@@ -51,7 +51,7 @@ fixed by[2]; //output samples
 fixed bx[2]; //input samples
 int bycount=0;
 
-inline fixed firby(fixed NewSample) {
+static inline fixed firby(fixed NewSample) {
     //Calculate the new output
     bx[bycount] = fixmul(ACoef[0],NewSample);
     by[bycount] = bx[0]+bx[1];


### PR DESCRIPTION
Hi there. Another two issues fixed in this PR:

Previously clicking the Elkulator main window close button would not exit Elkulator in linux.  Now in most situations it does (when it is running, and when the menus are being navigated (but not when a further dialog, like redefine keyboard, is running).  This was corrected by using the allegro close button callback to set variable quited to true (allowing the main code to exit).

The second issue was when attempting to build elkulator with debug symbols (configure --enable-debug, followed by make).  Linking of inline functions was failing due to updates to gcc.  This has also been fixed and elkulator can now be built and debugged with gdb. 

Tested Elkulator on Ubuntu 22.04 - no regressions found.

Comments and thoughts are invited.